### PR TITLE
Removed student toggle from the front end

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -3,10 +3,7 @@ import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
   // Stryker disable all : hard to test for query caching
-
   // Stryker enable all
-
-  // Stryker disable next-line all : TODO try to make a good test for this
 
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -3,27 +3,10 @@ import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
   // Stryker disable all : hard to test for query caching
-  function cellToAxiosParamsToggleStudent(cell) {
-    return {
-      url: "/api/admin/users/toggleStudent",
-      method: "POST",
-      params: {
-        id: cell.row.values.id,
-      },
-    };
-  }
 
-  const toggleStudentMutation = useBackendMutation(
-    cellToAxiosParamsToggleStudent,
-    {},
-    ["/api/admin/users"],
-  );
   // Stryker enable all
 
   // Stryker disable next-line all : TODO try to make a good test for this
-  const toggleStudentCallback = async (cell) => {
-    toggleStudentMutation.mutate(cell);
-  };
 
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
@@ -113,12 +96,6 @@ export default function UsersTable({ users }) {
       "Toggle Professor",
       "success",
       toggleProfessorCallback,
-      "UsersTable",
-    ),
-    ButtonColumn(
-      "Toggle Student",
-      "danger",
-      toggleStudentCallback,
       "UsersTable",
     ),
   ];

--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -37,7 +37,7 @@ public class User {
   @Builder.Default
   private Boolean admin=false;
   @Builder.Default
-  private Boolean student=false;
+  private Boolean student=true;
   @Builder.Default
   private Boolean professor=false;
 }


### PR DESCRIPTION
Closes #7 

Removed the front-end toggle for student role.

How to test:
1) Go to https://rec-leexe-dev.dokku-13.cs.ucsb.edu/
2) Login to ucsb account
3) Go to "Admin" and "Users" tabs on the navbar
4) The toggle button should not be there

<img width="1323" alt="Screenshot 2025-05-13 at 2 26 10 PM" src="https://github.com/user-attachments/assets/d09d1f7b-e7b8-4d4d-bc36-1fc247a81b56" />
