### PR TITLE
Tuan student back end removal

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -3,10 +3,7 @@ import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
   // Stryker disable all : hard to test for query caching
-
   // Stryker enable all
-
-  // Stryker disable next-line all : TODO try to make a good test for this
 
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -3,27 +3,10 @@ import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
   // Stryker disable all : hard to test for query caching
-  function cellToAxiosParamsToggleStudent(cell) {
-    return {
-      url: "/api/admin/users/toggleStudent",
-      method: "POST",
-      params: {
-        id: cell.row.values.id,
-      },
-    };
-  }
 
-  const toggleStudentMutation = useBackendMutation(
-    cellToAxiosParamsToggleStudent,
-    {},
-    ["/api/admin/users"],
-  );
   // Stryker enable all
 
   // Stryker disable next-line all : TODO try to make a good test for this
-  const toggleStudentCallback = async (cell) => {
-    toggleStudentMutation.mutate(cell);
-  };
 
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
@@ -113,12 +96,6 @@ export default function UsersTable({ users }) {
       "Toggle Professor",
       "success",
       toggleProfessorCallback,
-      "UsersTable",
-    ),
-    ButtonColumn(
-      "Toggle Student",
-      "danger",
-      toggleStudentCallback,
       "UsersTable",
     ),
   ];

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
@@ -126,16 +126,4 @@ public class UsersController extends ApiController {
         userRepository.save(user);
         return genericMessage("User with id %s has toggled professor status to %s".formatted(id, user.getProfessor()));
     }
-
-    @Operation(summary = "Toggle the student field")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/toggleStudent")
-    public Object toggleStudent( @Parameter(name = "id", description = "Long, id number of user to toggle their student field", example = "1", required = true) @RequestParam Long id){
-        User user = userRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
-
-        user.setStudent(!user.getStudent());
-        userRepository.save(user);
-        return genericMessage("User with id %s has toggled student status to %s".formatted(id, user.getStudent()));
-    }
 }

--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -37,7 +37,7 @@ public class User {
   @Builder.Default
   private Boolean admin=false;
   @Builder.Default
-  private Boolean student=false;
+  private Boolean student=true;
   @Builder.Default
   private Boolean professor=false;
 }

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
@@ -217,44 +217,6 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals("User with id 15 not found", json.get("message"));
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void admin_can_toggle_student() throws Exception{
-     User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(false).build();
-     when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
-             .andExpect(status().isOk()).andReturn();
-    
-    verify(userRepository, times(1)).findById(17L);
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("User with id 17 has toggled student status to true", json.get("message"));
-  }
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void admin_can_toggle_student_flip() throws Exception{
-     User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(true).build();
-     when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
-             .andExpect(status().isOk()).andReturn();
-    
-    verify(userRepository, times(1)).findById(17L);
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("User with id 17 has toggled student status to false", json.get("message"));
-  }
-
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void admin_cant_toggle_student_nonexistent() throws Exception{
-     User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).build();
-     when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=15").with(csrf()))
-             .andExpect(status().is(404)).andReturn();
-    
-    verify(userRepository, times(1)).findById(15L);
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("User with id 15 not found", json.get("message"));
-  }
-
   @WithMockUser(roles = { "USER" })
   @Test
   public void non_admin_can_get_all_professors() throws Exception{


### PR DESCRIPTION
Closes: #3 
Merge After #7 

I removed the student role toggle and tests related to the student role toggle from the back-end.

How to Test:
1) Go to https://rec-leexe-dev.dokku-13.cs.ucsb.edu/ and login with a ucsb account
2) Go to the "Swagger" tab on the nav bar
3) Scroll down to "User information (admin only except for /professors)" and there should be no ToggleStudent endpoint.

Before:
<img width="652" alt="Screenshot 2025-05-13 at 5 56 58 PM" src="https://github.com/user-attachments/assets/c8b64904-9d2f-41b8-9cad-45175e2ea6f9" />

After:
<img width="646" alt="Screenshot 2025-05-13 at 5 57 05 PM" src="https://github.com/user-attachments/assets/bdf73c38-60e7-4a43-947e-d2abbbb122e4" />