### PR TITLE
connersiou - added rec req table to pending requests page

### DIFF
--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -4,8 +4,7 @@ import RecommendationRequestTable from "main/components/RecommendationRequest/Re
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 export default function PendingRequestsPage() {
-  // Stryker disable all : placeholder for future implementation
-  const currentUser = useCurrentUser;
+  const { data: currentUser } = useCurrentUser();
 
   const apiEndpoint = hasRole(currentUser, "ROLE_PROFESSOR")
     ? "/api/recommendationrequest/professor/all"
@@ -18,7 +17,11 @@ export default function PendingRequestsPage() {
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
     [apiEndpoint],
-    { method: "GET", url: apiEndpoint },
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: apiEndpoint,
+    },
     // Stryker disable next-line all : don't test default value of empty list
     [],
   );
@@ -31,10 +34,12 @@ export default function PendingRequestsPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Pending Requests</h1>
-        <RecommendationRequestTable
-          requests={pendingRequests}
-          currentUser={currentUser}
-        />
+        <div data-testid="RecommendationRequestTable">
+          <RecommendationRequestTable
+            requests={pendingRequests}
+            currentUser={currentUser}
+          />
+        </div>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -1,11 +1,40 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useBackend } from "main/utils/useBackend";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 export default function PendingRequestsPage() {
   // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser;
+
+  const apiEndpoint = hasRole(currentUser, "ROLE_PROFESSOR")
+    ? "/api/recommendationrequest/professor/all"
+    : "/api/recommendationrequest/requester/all";
+
+  const {
+    data: requests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [apiEndpoint],
+    { method: "GET", url: apiEndpoint },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const pendingRequests = requests.filter(
+    (request) => request.status === "PENDING",
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Pending Requests page not yet implemented</h1>
+        <h1>Pending Requests</h1>
+        <RecommendationRequestTable
+          requests={pendingRequests}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
+++ b/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import PendingRequestsPage from "main/pages/Requests/PendingRequestsPage";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "pages/Requests/PendingRequestsPage",
+  component: PendingRequestsPage,
+};
+
+const Template = () => <PendingRequestsPage />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.professorUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/recommendationrequest/professor/all", () => {
+      return HttpResponse.json([]);
+    }),
+  ],
+};
+
+export const PendingRequests = Template.bind({});
+PendingRequests.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.professorUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/recommendationrequest/professor/all", () => {
+      return HttpResponse.json([
+        recommendationRequestFixtures.mixedRequests[2],
+      ]);
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -44,7 +44,7 @@ describe("PendingRequestsPage tests", () => {
     expect(
       screen.getByTestId("RecommendationRequestTable"),
     ).toBeInTheDocument();
-
+    
     await waitFor(() => {
       expect(
         screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-status`),
@@ -74,6 +74,86 @@ describe("PendingRequestsPage tests", () => {
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
     axiosMock.onGet("/api/recommendationrequest/professor/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+  });
+
+  test("Renders pending requests for student", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.studentUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock
+      .onGet("/api/recommendationrequest/requester/all")
+      .reply(200, recommendationRequestFixtures.mixedRequests);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-status`),
+      ).toBeInTheDocument();
+    });
+
+    const statusCells = screen.getAllByTestId(
+      /RecommendationRequestTable-cell-row-.*-col-status/,
+    );
+    expect(
+      statusCells.every((cell) => cell.textContent !== "COMPLETED"),
+    ).toBeTruthy();
+    expect(
+      statusCells.every((cell) => cell.textContent !== "DENIED"),
+    ).toBeTruthy();
+
+    expect(
+      statusCells.some((cell) => cell.textContent === "PENDING"),
+    ).toBeTruthy();
+  });
+
+  test("Renders empty table when no pending requests for student", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.studentUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/recommendationrequest/requester/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -44,7 +44,7 @@ describe("PendingRequestsPage tests", () => {
     expect(
       screen.getByTestId("RecommendationRequestTable"),
     ).toBeInTheDocument();
-    
+
     await waitFor(() => {
       expect(
         screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-status`),

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -1,34 +1,33 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import PendingRequestsPage from "main/pages/Requests/PendingRequestsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 
 describe("PendingRequestsPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+  const queryClient = new QueryClient();
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
+  });
+
+  test("Renders pending requests for professor", async () => {
     axiosMock
       .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
+      .reply(200, apiCurrentUserFixtures.professorUser);
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+    axiosMock
+      .onGet("/api/recommendationrequest/professor/all")
+      .reply(200, recommendationRequestFixtures.mixedRequests);
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,7 +36,62 @@ describe("PendingRequestsPage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
-    await screen.findByText("Pending Requests page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText("Pending Requests")).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-status`),
+      ).toBeInTheDocument();
+    });
+
+    const statusCells = screen.getAllByTestId(
+      /RecommendationRequestTable-cell-row-.*-col-status/,
+    );
+    expect(
+      statusCells.every((cell) => cell.textContent !== "COMPLETED"),
+    ).toBeTruthy();
+    expect(
+      statusCells.every((cell) => cell.textContent !== "DENIED"),
+    ).toBeTruthy();
+
+    expect(
+      statusCells.some((cell) => cell.textContent === "PENDING"),
+    ).toBeTruthy();
+  });
+
+  test("Renders empty table when no pending requests", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.professorUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/recommendationrequest/professor/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #14 

In this PR, we added the recommendation request table to the pending requests page.

Dokku: https://rec-connersiou-dev.dokku-13.cs.ucsb.edu/

To test:
1. Sign in with UCSB email
2. Go to Users under the Admin tab
3. Toggle Professor/Student to true then refresh the page
4. Navigate to the pending requests page

<img width="1429" alt="image" src="https://github.com/user-attachments/assets/b957d276-d748-47f8-8cad-e0937ed61a5b" />


Storybook: https://681d4faffe0f6002f844d079-bpcnmgierg.chromatic.com/?path=/docs/pages-requests-pendingrequestspage--docs


<img width="1230" alt="image" src="https://github.com/user-attachments/assets/7583f732-eae1-4414-be36-877dcb9d81ba" />
