### PR TITLE
connersiou - prof can update status of requests in frontend

### DIFF
--- a/frontend/src/fixtures/recommendationRequestFixtures.js
+++ b/frontend/src/fixtures/recommendationRequestFixtures.js
@@ -176,6 +176,27 @@ const recommendationRequestFixtures = {
       completionDate: null,
       done: false,
     },
+    {
+      id: 9,
+      requesterEmail: "student9@ucsb.edu",
+      professorEmail: "professor1@ucsb.edu",
+      requester: {
+        fullName: "Student Nine",
+        email: "student9@ucsb.edu",
+      },
+      professor: {
+        fullName: "Professor One",
+        email: "professor1@ucsb.edu",
+      },
+      details: "In progress request",
+      recommendationType: "Graduate School",
+      status: "IN PROGRESS",
+      submissionDate: "2024-02-01T00:00:00",
+      dueDate: "2024-03-01T00:00:00",
+      lastModifiedDate: "2024-02-15T00:00:00",
+      completionDate: null,
+      done: false,
+    },
   ],
 };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.dropdown-cell-wrapper {
+  overflow: visible;
+}

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -1,5 +1,5 @@
 import { useTable, useSortBy } from "react-table";
-import { Table, Button } from "react-bootstrap";
+import { Table, Button, Dropdown } from "react-bootstrap";
 
 export default function OurTable({ columns, data, testid = "testid" }) {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
@@ -100,6 +100,43 @@ export function ButtonColumn(label, variant, callback, testid) {
       >
         {label}
       </Button>
+    ),
+  };
+  return column;
+}
+
+export function ButtonDropdownColumn(label, variant, callback, testid) {
+  const column = {
+    Header: label,
+    id: label,
+    Cell: ({ cell }) => (
+      <Dropdown className="dropdown-cell-wrapper">
+        <Dropdown.Toggle
+          variant={variant}
+          data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-dropdown`}
+        >
+          Update
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu>
+          {cell.row.values.status === "PENDING" && (
+            <>
+              <Dropdown.Item onClick={() => callback.Accept(cell)}>
+                Accept
+              </Dropdown.Item>
+              <Dropdown.Item onClick={() => callback.Deny(cell)}>
+                Deny
+              </Dropdown.Item>
+            </>
+          )}
+
+          {cell.row.values.status === "IN PROGRESS" && (
+            <Dropdown.Item onClick={() => callback.Complete(cell)}>
+              Complete
+            </Dropdown.Item>
+          )}
+        </Dropdown.Menu>
+      </Dropdown>
     ),
   };
   return column;

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -119,7 +119,7 @@ export function ButtonDropdownColumn(label, variant, callback, testid) {
         </Dropdown.Toggle>
 
         <Dropdown.Menu>
-          {cell.row.values.status === "PENDING" && (
+          {cell.row.original.status === "PENDING" && (
             <>
               <Dropdown.Item onClick={() => callback.Accept(cell)}>
                 Accept
@@ -130,7 +130,7 @@ export function ButtonDropdownColumn(label, variant, callback, testid) {
             </>
           )}
 
-          {cell.row.values.status === "IN PROGRESS" && (
+          {cell.row.original.status === "IN PROGRESS" && (
             <Dropdown.Item onClick={() => callback.Complete(cell)}>
               Complete
             </Dropdown.Item>

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -19,6 +19,7 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
   const location = useLocation();
 
   const isPendingPage = location.pathname.includes("pending");
+  const isCompletedPage = location.pathname.includes("completed");
 
   const editCallback = (cell) => {
     navigate(`/requests/edit/${cell.row.values.id}`);
@@ -177,7 +178,8 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
   if (
     hasRole(currentUser, "ROLE_USER") &&
     !hasRole(currentUser, "ROLE_ADMIN") &&
-    !hasRole(currentUser, "ROLE_PROFESSOR")
+    !isPendingPage &&
+    !isCompletedPage
   ) {
     columns.push(
       ButtonColumn(

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -33,9 +33,10 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
   // Stryker disable all : hard to test for query caching
 
   // when delete success, invalidate the correct query key (depending on user role)
-  const apiEndpoint = hasRole(currentUser, "ROLE_PROFESSOR")
-    ? "/api/recommendationrequest/professor/all"
-    : "/api/recommendationrequest/requester/all";
+  const apiEndpoint =
+    isPendingPage || isCompletedPage
+      ? "/api/recommendationrequest/professor/all"
+      : "/api/recommendationrequest/requester/all";
 
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -18,10 +18,10 @@ import { hasRole } from "main/utils/currentUser";
 export default function RecommendationRequestTable({ requests, currentUser }) {
   const navigate = useNavigate();
   const location = useLocation();
-  
+
   const isPendingPage = location.pathname.includes("pending");
   const isCompletedPage = location.pathname.includes("completed");
-  
+
   const editCallback = (cell) => {
     navigate(`/requests/edit/${cell.row.values.id}`);
   };

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -27,7 +27,8 @@ export default function PendingRequestsPage() {
   );
 
   const pendingRequests = requests.filter(
-    (request) => request.status === "PENDING",
+    (request) =>
+      request.status === "PENDING" || request.status === "IN PROGRESS",
   );
 
   return (

--- a/frontend/src/main/utils/RecommendationRequestUtils.js
+++ b/frontend/src/main/utils/RecommendationRequestUtils.js
@@ -14,3 +14,21 @@ export function cellToAxiosParamsDelete(cell) {
     },
   };
 }
+
+export function onUpdateStatusSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsUpdateStatus(cell, newStatus) {
+  return {
+    url: "/api/recommendationrequest/professor",
+    method: "PUT",
+    params: {
+      id: cell.row.values.id,
+    },
+    data: {
+      status: newStatus,
+    },
+  };
+}

--- a/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
+++ b/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
@@ -29,6 +29,11 @@ Empty.parameters = {
 
 export const PendingRequests = Template.bind({});
 PendingRequests.parameters = {
+  reactRouter: {
+    location: {
+      pathname: "/requests/pending",
+    },
+  },
   msw: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.professorUser);

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -31,8 +31,11 @@ describe("OurTable tests", () => {
       Header: "Column 2",
       accessor: "col2",
     },
+    {
+      Header: "Status",
+      accessor: "status",
+    },
     ButtonColumn("Click", "primary", clickMeCallback, "testId"),
-    ButtonDropdownColumn("Update", "info", clickMeCallback, "testId"),
   ];
 
   test("renders an empty table without crashing", () => {
@@ -90,55 +93,133 @@ describe("OurTable tests", () => {
   });
 });
 
-describe("ButtonDropdownColumn", () => {
+describe("ButtonDropdownColumn tests", () => {
   const mockAccept = jest.fn();
   const mockDeny = jest.fn();
   const mockComplete = jest.fn();
 
-  const _columns = [
+  const columns = [
+    {
+      Header: "Column 1",
+      accessor: "col1", // accessor is the "key" in the data
+    },
+    {
+      Header: "Column 2",
+      accessor: "col2",
+    },
     ButtonDropdownColumn(
       "Update",
       "info",
-      {
-        Accept: mockAccept,
-        Deny: mockDeny,
-        Complete: mockComplete,
-      },
+      { Accept: mockAccept, Deny: mockDeny, Complete: mockComplete },
       "testId",
     ),
   ];
 
-  // test("renders Accept and Deny for PENDING row and triggers Accept", async () => {
-  //   const data = [{ id: 1, status: "PENDING" }];
-  //   render(<OurTable data={data} columns={columns} />);
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
-  //   const toggle = await screen.findByTestId(
-  //     "testId-cell-row-0-col-Update-dropdown",
-  //   );
-  //   fireEvent.click(toggle);
+  test("The dropdown appears in the table", async () => {
+    const rows = [{ id: 5, status: "PENDING" }];
+    render(<OurTable columns={columns} data={rows} />);
 
-  //   const acceptItem = await screen.findByText("Accept");
-  //   fireEvent.click(acceptItem);
+    await screen.findByTestId("testId-cell-row-0-col-Update-dropdown");
+    const dropdown = screen.getByTestId(
+      "testId-cell-row-0-col-Update-dropdown",
+    );
+    expect(dropdown).toBeInTheDocument();
+  });
 
-  //   await waitFor(() => {
-  //     expect(mockAccept).toHaveBeenCalledTimes(1);
-  //   });
-  // });
+  test("The dropdown shows Accept and Deny buttons when request is PENDING", async () => {
+    const rows = [{ id: 5, status: "PENDING" }];
+    render(<OurTable columns={columns} data={rows} />);
 
-  // test("renders Complete for IN PROGRESS row and triggers Complete", async () => {
-  //   const data = [{ id: 2, status: "IN PROGRESS" }];
-  //   render(<OurTable data={data} columns={columns} />);
+    await screen.findByTestId("testId-cell-row-0-col-Update-dropdown");
+    const dropdown = screen.getByTestId(
+      "testId-cell-row-0-col-Update-dropdown",
+    );
+    fireEvent.click(dropdown);
 
-  //   const toggle = await screen.findByTestId(
-  //     "testId-cell-row-0-col-Update-dropdown",
-  //   );
-  //   fireEvent.click(toggle);
+    expect(await screen.findByText("Accept")).toBeInTheDocument();
+    expect(await screen.findByText("Deny")).toBeInTheDocument();
+  });
 
-  //   const completeItem = await screen.findByText("Complete");
-  //   fireEvent.click(completeItem);
+  test("Clicking accept/deny invokes correct callbacks", async () => {
+    const rows = [{ id: 5, status: "PENDING" }];
+    render(<OurTable columns={columns} data={rows} />);
 
-  //   await waitFor(() => {
-  //     expect(mockComplete).toHaveBeenCalledTimes(1);
-  //   });
-  // });
+    await screen.findByTestId("testId-cell-row-0-col-Update-dropdown");
+    const dropdown = screen.getByTestId(
+      "testId-cell-row-0-col-Update-dropdown",
+    );
+    fireEvent.click(dropdown);
+
+    await screen.findByText("Accept");
+    const accept = screen.getByText("Accept");
+    await screen.findByText("Deny");
+    const deny = screen.getByText("Deny");
+
+    fireEvent.click(accept);
+    await waitFor(() => expect(mockAccept).toBeCalledTimes(1));
+
+    fireEvent.click(deny);
+    await waitFor(() => expect(mockDeny).toBeCalledTimes(1));
+  });
+
+  test("The dropdown shows Complete button when request is IN PROGRESS", async () => {
+    const rows = [{ id: 5, status: "IN PROGRESS" }];
+    render(<OurTable columns={columns} data={rows} />);
+
+    await screen.findByTestId("testId-cell-row-0-col-Update-dropdown");
+    const dropdown = screen.getByTestId(
+      "testId-cell-row-0-col-Update-dropdown",
+    );
+    fireEvent.click(dropdown);
+
+    expect(await screen.findByText("Complete")).toBeInTheDocument();
+  });
+
+  test("Clicking complete invokes correct callback", async () => {
+    const rows = [{ id: 5, status: "IN PROGRESS" }];
+    render(<OurTable columns={columns} data={rows} />);
+
+    await screen.findByTestId("testId-cell-row-0-col-Update-dropdown");
+    const dropdown = screen.getByTestId(
+      "testId-cell-row-0-col-Update-dropdown",
+    );
+    fireEvent.click(dropdown);
+
+    await screen.findByText("Complete");
+    const complete = screen.getByText("Complete");
+
+    fireEvent.click(complete);
+    await waitFor(() => expect(mockComplete).toBeCalledTimes(1));
+  });
+
+  test("for PENDING status, Comoplete should not render", async () => {
+    const rows = [{ id: 5, status: "PENDING" }];
+    render(<OurTable columns={columns} data={rows} />);
+
+    await screen.findByTestId("testId-cell-row-0-col-Update-dropdown");
+    const dropdown = screen.getByTestId(
+      "testId-cell-row-0-col-Update-dropdown",
+    );
+    fireEvent.click(dropdown);
+
+    expect(screen.queryByText("Complete")).not.toBeInTheDocument();
+  });
+
+  test("for IN PROGRESS status, Accept and Deny should not render", async () => {
+    const rows = [{ id: 5, status: "IN PROGRESS" }];
+    render(<OurTable columns={columns} data={rows} />);
+
+    await screen.findByTestId("testId-cell-row-0-col-Update-dropdown");
+    const dropdown = screen.getByTestId(
+      "testId-cell-row-0-col-Update-dropdown",
+    );
+    fireEvent.click(dropdown);
+
+    expect(screen.queryByText("Accept")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deny")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -1,5 +1,8 @@
 import { render, waitFor, fireEvent, screen } from "@testing-library/react";
-import OurTable, { ButtonColumn } from "main/components/OurTable";
+import OurTable, {
+  ButtonColumn,
+  ButtonDropdownColumn,
+} from "main/components/OurTable";
 
 describe("OurTable tests", () => {
   const threeRows = [
@@ -29,6 +32,7 @@ describe("OurTable tests", () => {
       accessor: "col2",
     },
     ButtonColumn("Click", "primary", clickMeCallback, "testId"),
+    ButtonDropdownColumn("Update", "info", clickMeCallback, "testId"),
   ];
 
   test("renders an empty table without crashing", () => {
@@ -84,4 +88,57 @@ describe("OurTable tests", () => {
     fireEvent.click(col1Header);
     await screen.findByText("🔽");
   });
+});
+
+describe("ButtonDropdownColumn", () => {
+  const mockAccept = jest.fn();
+  const mockDeny = jest.fn();
+  const mockComplete = jest.fn();
+
+  const _columns = [
+    ButtonDropdownColumn(
+      "Update",
+      "info",
+      {
+        Accept: mockAccept,
+        Deny: mockDeny,
+        Complete: mockComplete,
+      },
+      "testId",
+    ),
+  ];
+
+  // test("renders Accept and Deny for PENDING row and triggers Accept", async () => {
+  //   const data = [{ id: 1, status: "PENDING" }];
+  //   render(<OurTable data={data} columns={columns} />);
+
+  //   const toggle = await screen.findByTestId(
+  //     "testId-cell-row-0-col-Update-dropdown",
+  //   );
+  //   fireEvent.click(toggle);
+
+  //   const acceptItem = await screen.findByText("Accept");
+  //   fireEvent.click(acceptItem);
+
+  //   await waitFor(() => {
+  //     expect(mockAccept).toHaveBeenCalledTimes(1);
+  //   });
+  // });
+
+  // test("renders Complete for IN PROGRESS row and triggers Complete", async () => {
+  //   const data = [{ id: 2, status: "IN PROGRESS" }];
+  //   render(<OurTable data={data} columns={columns} />);
+
+  //   const toggle = await screen.findByTestId(
+  //     "testId-cell-row-0-col-Update-dropdown",
+  //   );
+  //   fireEvent.click(toggle);
+
+  //   const completeItem = await screen.findByText("Complete");
+  //   fireEvent.click(completeItem);
+
+  //   await waitFor(() => {
+  //     expect(mockComplete).toHaveBeenCalledTimes(1);
+  //   });
+  // });
 });

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -64,6 +64,9 @@ describe("PendingRequestsPage tests", () => {
     expect(
       statusCells.some((cell) => cell.textContent === "PENDING"),
     ).toBeTruthy();
+    expect(
+      statusCells.some((cell) => cell.textContent === "IN PROGRESS"),
+    ).toBeTruthy();
   });
 
   test("Renders empty table when no pending requests", async () => {
@@ -143,6 +146,9 @@ describe("PendingRequestsPage tests", () => {
 
     expect(
       statusCells.some((cell) => cell.textContent === "PENDING"),
+    ).toBeTruthy();
+    expect(
+      statusCells.some((cell) => cell.textContent === "IN PROGRESS"),
     ).toBeTruthy();
   });
 

--- a/frontend/src/tests/utils/RecommendationRequestUtils.test.js
+++ b/frontend/src/tests/utils/RecommendationRequestUtils.test.js
@@ -1,6 +1,9 @@
 import {
   onDeleteSuccess,
   cellToAxiosParamsDelete,
+  onUpdateStatusSuccess,
+  _cellToAxiosParamsUpdateStatus,
+  cellToAxiosParamsUpdateStatus,
 } from "main/utils/RecommendationRequestUtils";
 import mockConsole from "jest-mock-console";
 
@@ -44,6 +47,40 @@ describe("RecommendationRequestUtils", () => {
         url: "/api/recommendationrequest",
         method: "DELETE",
         params: { id: 17 },
+      });
+    });
+  });
+  describe("onUpdateStatusSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onUpdateStatusSuccess("abc");
+      // asserts
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsUpdateStatus", () => {
+    test("It returns the correct params and data", () => {
+      // arrange
+      const cell = { row: { values: { id: 17 } } };
+      const newStatus = "DENIED";
+
+      // act
+      const result = cellToAxiosParamsUpdateStatus(cell, newStatus);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/recommendationrequest/professor",
+        method: "PUT",
+        params: { id: 17 },
+        data: { status: "DENIED" },
       });
     });
   });


### PR DESCRIPTION
Closes #10 

In this PR, we add an Update dropdown menu so that professors can accept or deny pending requests. Then, when requests are accepted and in progress, professors can use the same menu to update the request to Completed.

To test:
1. Log onto my dokku deployment
2. Use two emails, one as a professor, one that's not (aka a student)
3. As a student/non-professor, create some recommendation requests through Swagger for the email that's a professor
4. Switch back to the professor account and check the Pending Requests page
5. You should be able to click the update dropdown and accept/deny the request
6. When a request is IN PROGRESS, you should be see just "Complete" under the update dropdown.

[Dokku](https://rec-connersiou-dev.dokku-13.cs.ucsb.edu/)