### PR TITLE
timothy - edited request controller to add completion date when request completed

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -134,9 +135,8 @@ public class RecommendationRequestController extends ApiController {
 
         recommendationRequest.setStatus(incoming.getStatus());
 
-        if ("COMPLETED".equalsIgnoreCase(incoming.getStatus())
-        && recommendationRequest.getCompletionDate() == null) {
-        recommendationRequest.setCompletionDate(LocalDateTime.now());
+        if ("COMPLETED".equalsIgnoreCase(incoming.getStatus())) {
+        recommendationRequest.setCompletionDate(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES));
     }
 
         recommendationRequestRepository.save(recommendationRequest);

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -130,7 +130,14 @@ public class RecommendationRequestController extends ApiController {
                 .findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
 
+                
+
         recommendationRequest.setStatus(incoming.getStatus());
+
+        if ("COMPLETED".equalsIgnoreCase(incoming.getStatus())
+        && recommendationRequest.getCompletionDate() == null) {
+        recommendationRequest.setCompletionDate(LocalDateTime.now());
+    }
 
         recommendationRequestRepository.save(recommendationRequest);
 

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
@@ -4,6 +4,7 @@ import edu.ucsb.cs156.rec.entities.User;
 import edu.ucsb.cs156.rec.repositories.UserRepository;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -23,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cglib.core.Local;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -454,8 +456,9 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
         // Prof can edit a Recommendation Request
         @WithMockUser(roles = { "PROFESSOR" })
         @Test
-        public void prof_can_put_recommendation_request() throws Exception {
+        public void prof_can_put_complete_recommendation_request() throws Exception {
                 // arrange
+                LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
                 User student = User.builder().id(99).build();
                 User prof = User.builder()
                                 .id(22L)
@@ -488,7 +491,7 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
                                 .recommendationType("PhDprogram")
                                 .details("details")
                                 .status("COMPLETED")
-                                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .completionDate(now)
                                 .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                                 .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                                 .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
@@ -500,6 +503,86 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
                                 .recommendationType("PhDprogram")
                                 .details("details")
                                 .status("COMPLETED")
+                                .completionDate(now)
+                                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .build();
+
+
+                String requestBody = mapper.writeValueAsString(rec_updated);
+                String expectedJson = mapper.writeValueAsString(rec_corrected);
+
+                when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(rec));
+
+                // act
+                MvcResult response = mockMvc
+                                .perform(put("/api/recommendationrequest/professor?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                // assert
+
+                verify(recommendationRequestRepository, times(1)).findById(67L);
+                verify(recommendationRequestRepository, times(1)).save(rec_corrected);
+
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Prof can edit a Recommendation Request
+        @WithMockUser(roles = { "PROFESSOR" })
+        @Test
+        public void prof_can_put_incomplete_recommendation_request() throws Exception {
+                // arrange
+                User student = User.builder().id(99).build();
+                User prof = User.builder()
+                                .id(22L)
+                                .email("profA@ucsb.edu")
+                                .googleSub("googleSub")
+                                .fullName("Prof A")
+                                .givenName("Prof")
+                                .familyName("A")
+                                .emailVerified(true)
+                                .professor(true)
+                                .build();
+
+                RecommendationRequest rec = RecommendationRequest.builder()
+                                .id(67L)
+                                .requester(student)
+                                .professor(prof)
+                                .recommendationType("PhDprogram")
+                                .details("details")
+                                .status("PENDING")
+                                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .build();
+
+                RecommendationRequest rec_updated = RecommendationRequest.builder()
+                                .id(67L)
+                                .requester(student)
+                                .professor(prof)
+                                .recommendationType("PhDprogram")
+                                .details("details")
+                                .status("STILL_PENDING")
+                                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                                .build();
+                RecommendationRequest rec_corrected = RecommendationRequest.builder()
+                                .id(67L)
+                                .requester(student)
+                                .professor(prof)
+                                .recommendationType("PhDprogram")
+                                .details("details")
+                                .status("STILL_PENDING")
                                 .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                                 .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                                 .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))


### PR DESCRIPTION
closes #17 (and also #21)?

In this PR, I edited the controller so that when a professor edits a request's status to be "Completed," it stores the current LocalDateTime.  

I also added tests (for complete and incomplete updates) for full mutation and line coverage

On local host, the completion date now shows: 

<img width="1457" alt="image" src="https://github.com/user-attachments/assets/bb2248b9-209e-4e16-8fb2-f8d64fdf8b95" />

Deployed here:
https://rec-timothytwu-dev.dokku-13.cs.ucsb.edu/

To test, make a new recommendation request in Swagger, edit the request to have status "Completed," and check that the  completion date is stored in the table.

*Note for future: I truncated the LocalDateTime for completed date displayed in the table to the minute for testing purposes


