### PR TITLE
connersiou - added a delete endpoint for professor and changed some logic

### DIFF
--- a/frontend/src/fixtures/recommendationRequestFixtures.js
+++ b/frontend/src/fixtures/recommendationRequestFixtures.js
@@ -25,8 +25,9 @@ const recommendationRequestFixtures = {
   threeRecommendations: [
     {
       id: 2,
-      professor_id: 2,
+      professor_id: 3,
       professor: {
+        id: 3,
         fullName: "Chaewon Bang",
         email: "chaewonbang@ucsb.edu",
       },
@@ -39,6 +40,7 @@ const recommendationRequestFixtures = {
       recommendationType: "CS Department BS/MS program",
       requester_id: 2,
       requester: {
+        id: 2,
         fullName: "Mia Scott",
         email: "mscott@ucsb.edu",
       },

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -12,7 +12,6 @@ import {
   cellToAxiosParamsUpdateStatus,
   onUpdateStatusSuccess,
 } from "main/utils/RecommendationRequestUtils";
-
 import { useNavigate, useLocation } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
@@ -30,16 +29,15 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
   // Stryker disable all : hard to test for query caching
 
   // when delete success, invalidate the correct query key (depending on user role)
-
   const apiEndpoint =
     isPendingPage || isCompletedPage
       ? "/api/recommendationrequest/professor/all"
       : "/api/recommendationrequest/requester/all";
 
   const deleteMutation = useBackendMutation(
-    cellToAxiosParamsDelete,
+    (cell) => cellToAxiosParamsDelete(cell, currentUser),
     { onSuccess: onDeleteSuccess },
-    [apiEndpoint],
+    apiEndpoint,
   );
 
   // Stryker restore all

--- a/frontend/src/main/utils/RecommendationRequestUtils.js
+++ b/frontend/src/main/utils/RecommendationRequestUtils.js
@@ -1,18 +1,35 @@
 import { toast } from "react-toastify";
+import { hasRole } from "main/utils/currentUser";
 
 export function onDeleteSuccess(message) {
   console.log(message);
   toast(message);
 }
 
-export function cellToAxiosParamsDelete(cell) {
-  return {
-    url: "/api/recommendationrequest",
-    method: "DELETE",
-    params: {
-      id: cell.row.values.id,
-    },
-  };
+export function cellToAxiosParamsDelete(cell, currentUser) {
+  const { requester, professor, id } = cell.row.original;
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    return {
+      url: "/api/recommendationrequest/admin",
+      method: "DELETE",
+      params: { id },
+    };
+  } else if (requester.id === currentUser.root.user.id) {
+    return {
+      url: "/api/recommendationrequest",
+      method: "DELETE",
+      params: { id },
+    };
+  } else if (professor.id === currentUser.root.user.id) {
+    return {
+      url: "/api/recommendationrequest/professor",
+      method: "DELETE",
+      params: { id },
+    };
+  } else {
+    throw new Error("Not authorized to delete this request");
+  }
 }
 
 export const formattedDate = (val) => {

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -10,7 +10,7 @@ import { hasRole } from "main/utils/currentUser";
 import { toast } from "react-toastify";
 
 const mockedNavigate = jest.fn();
-const mockedLocation = { pathname: "" };
+let mockedLocation = { pathname: "" };
 
 jest.mock("react-router-dom", () => {
   const actual = jest.requireActual("react-router-dom");
@@ -29,7 +29,6 @@ describe("RecommendationRequestTable apiEndpoint invalidation", () => {
   beforeEach(() => {
     queryClient = new QueryClient();
     invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
-
     axiosMock.onDelete().reply(200, { message: "deleted" });
   });
 
@@ -39,7 +38,7 @@ describe("RecommendationRequestTable apiEndpoint invalidation", () => {
   });
 
   test("invalidates '/api/recommendationrequest/requester/all' on a non-pending/non-completed page", async () => {
-    mockedLocation.pathname = "/profile";
+    mockedLocation = { pathname: "/profile" };
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -78,7 +77,7 @@ describe("RecommendationRequestTable apiEndpoint invalidation", () => {
   });
 
   test("invalidates '/api/recommendationrequest/professor/all' on a pending page", async () => {
-    mockedLocation.pathname = "/requests/pending";
+    mockedLocation = { pathname: "/requests/pending" };
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -122,13 +121,14 @@ describe("UserTable tests", () => {
 
   test("Has the expected column headers and content for ordinary user", () => {
     const currentUser = currentUserFixtures.userOnly;
+    mockedLocation = { pathname: "/profile" };
 
     expect(hasRole(currentUser, "ROLE_USER")).toBe(true);
     expect(hasRole(currentUser, "ROLE_ADMIN")).toBe(false);
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={["/profile"]}>
           <RecommendationRequestTable
             requests={recommendationRequestFixtures.threeRecommendations}
             currentUser={currentUser}
@@ -219,13 +219,14 @@ describe("UserTable tests", () => {
 
   test("Has the expected column headers and content for adminUser", () => {
     const currentUser = currentUserFixtures.adminUser;
+    mockedLocation = { pathname: "/profile" };
 
     expect(hasRole(currentUser, "ROLE_ADMIN")).toBe(true);
     expect(hasRole(currentUser, "ROLE_USER")).toBe(true);
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={["/profile"]}>
           <RecommendationRequestTable
             requests={recommendationRequestFixtures.threeRecommendations}
             currentUser={currentUser}
@@ -295,13 +296,14 @@ describe("UserTable tests", () => {
 
   test("Edit button navigates to the edit page for user", async () => {
     const currentUser = currentUserFixtures.userOnly;
+    mockedLocation = { pathname: "/profile" };
 
     expect(hasRole(currentUser, "ROLE_USER")).toBe(true);
     expect(hasRole(currentUser, "ROLE_ADMIN")).toBe(false);
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={["/profile"]}>
           <RecommendationRequestTable
             requests={recommendationRequestFixtures.threeRecommendations}
             currentUser={currentUser}
@@ -331,12 +333,13 @@ describe("UserTable tests", () => {
   //Added for mutation coverage for the case in which the user is neither a user nor an admin
   test("A user with no roles has expected content", () => {
     const currentUser = currentUserFixtures.notLoggedIn;
+    mockedLocation = { pathname: "/profile" };
 
     expect(hasRole(currentUser, "ROLE_USER")).toBe(undefined);
 
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={["/profile"]}>
           <RecommendationRequestTable
             requests={recommendationRequestFixtures.threeRecommendations}
             currentUser={currentUser}
@@ -362,6 +365,7 @@ describe("UserTable tests", () => {
   test("Delete button calls delete callback (for requester)", async () => {
     // arrange
     const currentUser = currentUserFixtures.userOnly;
+    mockedLocation = { pathname: "/profile" };
 
     const axiosMock = new AxiosMockAdapter(axios);
     axiosMock
@@ -408,6 +412,7 @@ describe("UserTable tests", () => {
   test("Delete button calls delete callback (admin)", async () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;
+    mockedLocation = { pathname: "/requests/completed" };
 
     const axiosMock = new AxiosMockAdapter(axios);
     axiosMock
@@ -455,6 +460,7 @@ describe("UserTable tests", () => {
   test("Delete button calls delete callback (professor)", async () => {
     // arrange
     const currentUser = currentUserFixtures.professorUser;
+    mockedLocation = { pathname: "/requests/pending" };
 
     const axiosMock = new AxiosMockAdapter(axios);
     axiosMock
@@ -523,6 +529,7 @@ describe("RecommendationRequestTable update mutation", () => {
   test("Clicking Accept sends PUT with IN PROGRESS and toasts success", async () => {
     const currentUser = currentUserFixtures.professorUser;
     const rows = recommendationRequestFixtures.mixedRequests;
+    mockedLocation = { pathname: "/requests/pending" };
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -558,6 +565,7 @@ describe("RecommendationRequestTable update mutation", () => {
   test("Clicking Deny sends PUT with DENIED and toasts success", async () => {
     const currentUser = currentUserFixtures.professorUser;
     const rows = recommendationRequestFixtures.mixedRequests;
+    mockedLocation = { pathname: "/requests/pending" };
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -592,6 +600,7 @@ describe("RecommendationRequestTable update mutation", () => {
   test("Clicking Complete sends PUT with Completed and toasts success", async () => {
     const currentUser = currentUserFixtures.professorUser;
     const rows = recommendationRequestFixtures.mixedRequests;
+    mockedLocation = { pathname: "/requests/pending" };
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -623,9 +632,10 @@ describe("RecommendationRequestTable update mutation", () => {
     expect(toast).toHaveBeenCalledWith("Request marked as COMPLETED.");
   });
 
-  test("Update button not render for a non-professor even on the pending page", async () => {
+  test("Update button not render for a non-professor on the pending page", async () => {
     const currentUser = currentUserFixtures.userOnly;
     const rows = recommendationRequestFixtures.mixedRequests;
+    mockedLocation = { pathname: "/requests/pending" };
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -652,38 +662,10 @@ describe("RecommendationRequestTable update mutation", () => {
     ).toBeNull();
   });
 
-  test("Update button not render for a professor on a non-pending page", async () => {
-    const currentUser = currentUserFixtures.professorUser;
-    const rows = recommendationRequestFixtures.mixedRequests;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={["/requests/completed"]}>
-          <Routes>
-            <Route
-              path="/requests/completed"
-              element={
-                <RecommendationRequestTable
-                  requests={rows}
-                  currentUser={currentUser}
-                />
-              }
-            />
-          </Routes>
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-
-    expect(
-      screen.queryByTestId(
-        "RecommendationRequestTable-cell-row-0-col-Update-dropdown",
-      ),
-    ).toBeNull();
-  });
-
   test("Passes the correct status into the Accept callback", async () => {
     const currentUser = currentUserFixtures.professorUser;
     const rows = recommendationRequestFixtures.mixedRequests;
+    mockedLocation = { pathname: "/requests/pending" };
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -719,6 +701,7 @@ describe("RecommendationRequestTable update mutation", () => {
   test("Passes the correct status into the Deny callback", async () => {
     const currentUser = currentUserFixtures.professorUser;
     const rows = recommendationRequestFixtures.mixedRequests;
+    mockedLocation = { pathname: "/requests/pending" };
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -754,6 +737,7 @@ describe("RecommendationRequestTable update mutation", () => {
   test("Passes the correct status into the Complete callback", async () => {
     const currentUser = currentUserFixtures.professorUser;
     const rows = recommendationRequestFixtures.mixedRequests;
+    mockedLocation = { pathname: "/requests/pending" };
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -790,6 +774,7 @@ describe("RecommendationRequestTable update mutation", () => {
     const apiEndpoint = "/api/recommendationrequest/professor/all";
     const queryClient = new QueryClient();
     const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+    mockedLocation = { pathname: "/requests/pending" };
 
     const currentUser = currentUserFixtures.professorUser;
     const rows = recommendationRequestFixtures.mixedRequests;
@@ -831,6 +816,7 @@ describe("RecommendationRequestTable update mutation", () => {
       require("main/utils/RecommendationRequestUtils"),
       "onUpdateStatusSuccess",
     );
+    mockedLocation = { pathname: "/requests/pending" };
 
     const currentUser = currentUserFixtures.professorUser;
     const rows = recommendationRequestFixtures.mixedRequests;

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -86,6 +86,28 @@ public class RecommendationRequestController extends ApiController {
     }
 
     /**
+     * The professor can delete incoming RecommendationRequests
+     * 
+     * @param id the id of the RecommendationRequest to delete
+     * @return a message indicating that the RecommendationRequest was deleted
+     */
+    @Operation(summary = "Professor can delete their incoming RecommendationRequest")
+    @PreAuthorize("hasRole('ROLE_PROFESSOR')")
+    @DeleteMapping("/professor")
+    public Object deleteRecommendationRequestAsProfessor(@Parameter(name = "id") @RequestParam Long id) {
+        User currentUser = getCurrentUser().getUser(); 
+        RecommendationRequest recommendationRequest = 
+        recommendationRequestRepository
+            .findByIdAndProfessor(id, currentUser)
+            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        recommendationRequestRepository.delete(recommendationRequest);
+
+        return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
+    }
+
+
+    /**
      * The user who posted a RecommendationRequest can update their RecommendationRequest
      * 
      * @param id       the id of the Recommendation Request to update

--- a/src/main/java/edu/ucsb/cs156/rec/repositories/RecommendationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/rec/repositories/RecommendationRequestRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecommendationRequestRepository extends CrudRepository<RecommendationRequest, Long> {
-   Optional<RecommendationRequest> findByIdAndRequester(long id, User requester_id);
+  Optional<RecommendationRequest> findByIdAndRequester(long id, User requester_id);
  /**
    * This method returns an iterable of recommendation requests with given requester_id.
    * @param requester_id requester_id within RecommendationRequest that maps to id in User table
@@ -26,6 +26,14 @@ public interface RecommendationRequestRepository extends CrudRepository<Recommen
    * @return iterable of RecommendationRequests with professor_id == professor_id
    */
   Iterable<RecommendationRequest> findAllByProfessorId(Long professor_id);
+
+  /**
+   * This method returns an iterable of recommendation requests with given professor_id.
+   * @param id id of the RecommendationRequest
+   * @param professor_id professor (User object)
+   * @return instance of RecommendationRequest with id == id, professor_id == professor_id
+   */
+  Optional<RecommendationRequest> findByIdAndProfessor(long id, User professor_id);
 
   /**
    * Find all recommendation requests by professor ID and status.


### PR DESCRIPTION
Closes #50 

In this PR, we add a delete endpoint for professors to use on the pending/completed pages in comparison to the regular delete endpoint for requesters to use on their student profile.

[Dokku](https://rec-connersiou-dev.dokku-13.cs.ucsb.edu/)

To test:
1. Log in on UCSB email
2. Log in on another email to serve as a professor
3. Log back onto the UCSB account to set the other email as a professor and create some requests for the professor email
4. Try the delete buttons on the pending/completed pages as the professor email
