### PR TITLE
Nikunj - Fix Admin Page Self-Toggle Bug

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -29,11 +29,14 @@ export default function UsersTable({ users, currentUser }) {
 
   // Stryker disable next-line all : TODO try to make a good test for this
   const toggleAdminCallback = async (cell) => {
-    if (currentUser && currentUser.loggedIn 
-        && currentUser.root.user.email === cell.row.values.email) {
-        toggleAdminMutation.mutate(cell);
-        toast("admin privileges removed");
-      navigate('/'); // Redirect after showing the toast
+    if (
+      currentUser &&
+      currentUser.loggedIn &&
+      currentUser.root.user.email === cell.row.values.email
+    ) {
+      toggleAdminMutation.mutate(cell);
+      toast("admin privileges removed");
+      navigate("/"); // Redirect after showing the toast
     } else {
       toggleAdminMutation.mutate(cell);
     }

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -5,9 +5,6 @@ import axios from "axios";
 import { useMutation, useQueryClient } from "react-query";
 
 export default function UsersTable({ users }) {
-  // Stryker disable all : hard to test for query caching
-  // Stryker enable all
-
   const queryClient = useQueryClient();
 
   //toggleAdmin

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,12 +1,14 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
-import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import axios from "axios";
+import { useMutation, useQueryClient } from "react-query";
 
-export default function UsersTable({ users, currentUser }) {
-  const navigate = useNavigate();
+export default function UsersTable({ users }) {
   // Stryker disable all : hard to test for query caching
   // Stryker enable all
+
+  const queryClient = useQueryClient();
 
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
@@ -19,27 +21,37 @@ export default function UsersTable({ users, currentUser }) {
     };
   }
 
-  // Stryker disable all : hard to test for query caching
-  const toggleAdminMutation = useBackendMutation(
-    cellToAxiosParamsToggleAdmin,
-    {},
-    ["/api/admin/users"],
+  // Custom mutation that handles errors without the default Axios error
+  const toggleAdminMutation = useMutation(
+    async (cell) => {
+      try {
+        const params = cellToAxiosParamsToggleAdmin(cell);
+        const response = await axios(params);
+        return response.data;
+      } catch (error) {
+        if (
+          error.response &&
+          error.response.data &&
+          error.response.data.message
+        ) {
+          toast(`Error: ${error.response.data.message}`);
+        } else {
+          toast(`Error: ${error.message || "Unknown error occurred"}`);
+        }
+        throw error; // Re-throw to maintain error state in mutation
+      }
+    },
+    {
+      onSettled: () => {
+        queryClient.invalidateQueries(["/api/admin/users"]);
+      },
+      retry: false,
+    },
   );
-  // Stryker enable all
 
   // Stryker disable next-line all : TODO try to make a good test for this
   const toggleAdminCallback = async (cell) => {
-    if (
-      currentUser &&
-      currentUser.loggedIn &&
-      currentUser.root.user.email === cell.row.values.email
-    ) {
-      toggleAdminMutation.mutate(cell);
-      toast("admin privileges removed");
-      navigate("/"); // Redirect after showing the toast
-    } else {
-      toggleAdminMutation.mutate(cell);
-    }
+    toggleAdminMutation.mutate(cell);
   };
 
   function cellToAxiosParamsToggleProfessor(cell) {

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,7 +1,10 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 
-export default function UsersTable({ users }) {
+export default function UsersTable({ users, currentUser }) {
+  const navigate = useNavigate();
   // Stryker disable all : hard to test for query caching
   // Stryker enable all
 
@@ -26,7 +29,14 @@ export default function UsersTable({ users }) {
 
   // Stryker disable next-line all : TODO try to make a good test for this
   const toggleAdminCallback = async (cell) => {
-    toggleAdminMutation.mutate(cell);
+    if (currentUser && currentUser.loggedIn 
+        && currentUser.root.user.email === cell.row.values.email) {
+        toggleAdminMutation.mutate(cell);
+        toast("admin privileges removed");
+      navigate('/'); // Redirect after showing the toast
+    } else {
+      toggleAdminMutation.mutate(cell);
+    }
   };
 
   function cellToAxiosParamsToggleProfessor(cell) {

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -1,8 +1,9 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import UsersTable from "main/components/Users/UsersTable";
-
+import { useCurrentUser } from "main/utils/currentUser";
 import { useBackend } from "main/utils/useBackend";
 const AdminUsersPage = () => {
+  const { data: currentUser } = useCurrentUser();
   const {
     data: users,
     error: _error,
@@ -17,7 +18,7 @@ const AdminUsersPage = () => {
   return (
     <BasicLayout>
       <h2>Users</h2>
-      <UsersTable users={users} />
+      <UsersTable users={users} currentUser={currentUser} />
     </BasicLayout>
   );
 };

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -2,6 +2,7 @@ import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
 import UsersTable from "main/components/Users/UsersTable";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
@@ -22,7 +23,9 @@ describe("UserTable tests", () => {
   test("renders without crashing for empty table", () => {
     render(
       <QueryClientProvider client={queryClient}>
-        <UsersTable users={[]} />
+        <MemoryRouter>
+          <UsersTable users={[]} />
+        </MemoryRouter>
       </QueryClientProvider>,
     );
   });
@@ -30,7 +33,9 @@ describe("UserTable tests", () => {
   test("renders without crashing for three users", () => {
     render(
       <QueryClientProvider client={queryClient}>
-        <UsersTable users={usersFixtures.threeUsers} />
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} />
+        </MemoryRouter>
       </QueryClientProvider>,
     );
   });
@@ -38,7 +43,9 @@ describe("UserTable tests", () => {
   test("Has the expected colum headers and content", () => {
     render(
       <QueryClientProvider client={queryClient}>
-        <UsersTable users={usersFixtures.threeUsers} />
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} />
+        </MemoryRouter>
       </QueryClientProvider>,
     );
 
@@ -110,10 +117,12 @@ describe("UserTable tests", () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <UsersTable
-          users={usersFixtures.threeUsers}
-          currentUser={currentUser}
-        />
+        <MemoryRouter>
+          <UsersTable
+            users={usersFixtures.threeUsers}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
       </QueryClientProvider>,
     );
 
@@ -146,10 +155,12 @@ describe("UserTable tests", () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <UsersTable
-          users={usersFixtures.threeUsers}
-          currentUser={currentUser}
-        />
+        <MemoryRouter>
+          <UsersTable
+            users={usersFixtures.threeUsers}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
       </QueryClientProvider>,
     );
 

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -319,7 +319,9 @@ describe("UserTable tests", () => {
       .mockImplementation(() => {});
 
     axiosMock.onPost("/api/admin/users/toggleAdmin").reply(() => {
-      throw new Error("Test error");
+      const error = new Error();
+      error.response = { data: {} };
+      throw error;
     });
 
     render(

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -319,7 +319,7 @@ describe("UserTable tests", () => {
       .mockImplementation(() => {});
 
     axiosMock.onPost("/api/admin/users/toggleAdmin").reply(() => {
-      throw { response: { data: {} } };
+      throw new Error("Test error");
     });
 
     render(

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
@@ -110,6 +110,14 @@ public class UsersController extends ApiController {
         User user = userRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
+        // Get the current user
+        User currentUser = getCurrentUser().getUser();
+        
+        // Check if the user is trying to remove admin from themselves
+        if (user.getId() == currentUser.getId() && user.getAdmin()) {
+            throw new IllegalArgumentException("Cannot remove admin from currently logged in user; ask another admin to do that.");
+        }
+
         user.setAdmin(!user.getAdmin());
         userRepository.save(user);
         return genericMessage("User with id %s has toggled admin status to %s".formatted(id, user.getAdmin()));

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
@@ -233,6 +233,22 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals("Cannot remove admin from currently logged in user; ask another admin to do that.", json.get("message"));
   }
 
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_add_admin_status_to_themselves() throws Exception{
+     // Mock the current user to have ID 1 (which is the mock current user ID) and admin status false
+     User currentUser = User.builder().email("user@example.org").id(1L).admin(false).build();
+     when(userRepository.findById(eq(1L))).thenReturn(Optional.of(currentUser));
+     
+     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleAdmin?id=1").with(csrf()))
+             .andExpect(status().isOk()).andReturn();
+    
+    verify(userRepository, times(1)).findById(1L);
+    verify(userRepository, times(1)).save(any(User.class)); // Should save because no exception is thrown
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("User with id 1 has toggled admin status to true", json.get("message"));
+  }
+
   @WithMockUser(roles = { "USER" })
   @Test
   public void non_admin_can_get_all_professors() throws Exception{


### PR DESCRIPTION
Closes #43 

This is a simple QoL fix for admin users using the admin page. In the chance that they click "toggle admin" on themselves, they remove access to api endpoints on that page, which causes API errors. 

I fixed this bug by implementing a custom backend error, and a handler to propagate the error to the frontend. 

To test: try toggling admin on yourself on localhost or [dokku](https://rec-nikunjparasar-dev.dokku-13.cs.ucsb.edu)

<img width="322" alt="image" src="https://github.com/user-attachments/assets/e3a618fa-cbd2-4b49-ae62-758d22e403d1" />
