### PR TITLE
Tuan - Nav Bar Permission Changes

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -61,7 +61,7 @@ export default function AppNavbar({
                   </NavDropdown.Item>
                 </NavDropdown>
               )}
-              {hasRole(currentUser, "ROLE_USER") && (
+              {hasRole(currentUser, "ROLE_PROFESSOR") && (
                 <>
                   <Nav.Link as={Link} to="/requests/pending">
                     Pending Requests

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -189,7 +189,7 @@ describe("AppNavbar tests", () => {
     expect(statisticsLink).toBeInTheDocument();
   });
 
-  test("renders the three prof pages correctly for normal users", async () => {
+  test("the three prof pages can not be seen by basic users", async () => {
     const currentUser = currentUserFixtures.userOnly;
     const systemInfo = systemInfoFixtures.showingBoth;
     const doLogin = jest.fn();
@@ -206,17 +206,9 @@ describe("AppNavbar tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Pending Requests");
-    const pendingLink = screen.getByText("Pending Requests");
-    expect(pendingLink).toBeInTheDocument();
-
-    await screen.findByText("Completed Requests");
-    const completedLink = screen.getByText("Completed Requests");
-    expect(completedLink).toBeInTheDocument();
-
-    await screen.findByText("Statistics");
-    const statisticsLink = screen.getByText("Statistics");
-    expect(statisticsLink).toBeInTheDocument();
+    expect(screen.queryByText("Pending Requests")).not.toBeInTheDocument();
+    expect(screen.queryByText("Completed Requests")).not.toBeInTheDocument();
+    expect(screen.queryByText("Statistics")).not.toBeInTheDocument();
   });
 
   test("the three prof pages do not show when not logged in", async () => {


### PR DESCRIPTION
Closes #36

I change the nav bar so that only users with the professor roles see the three pages: "pending," "completed," and "statistics." 

How To Test:
1) Go to https://rec-leexe-dev.dokku-13.cs.ucsb.edu/
2) Log into a ucsb account 
3) By default, you should not be able to see the three pages since you don't have the professor role
3) Look at the navbar and click on the "Admin" dropdown and  then "Users" tab
4) Toggle yourself as a professor
5) Refresh the page and you should be able to see your professor 

No Professor Role:
<img width="1326" alt="Screenshot 2025-05-21 at 1 12 05 PM" src="https://github.com/user-attachments/assets/e791a9d7-6123-45b8-bab4-aeffadca0c1f" />

With Professor Role:
<img width="1340" alt="Screenshot 2025-05-21 at 1 12 20 PM" src="https://github.com/user-attachments/assets/85a8482d-a638-4927-ba90-877efaf3b709" />
