### PR TITLE
kenneth - moved formatted date function to utils and created util tests

### DIFF
--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -5,6 +5,7 @@ import { useBackendMutation } from "main/utils/useBackend";
 import {
   cellToAxiosParamsDelete,
   onDeleteSuccess,
+  formattedDate,
 } from "main/utils/RecommendationRequestUtils";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
@@ -16,11 +17,6 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
     navigate(`/requests/edit/${cell.row.values.id}`);
   };
 
-  const formattedDate = (val) => {
-    const date = new Date(val);
-    const formattedDate = `${String(date.getMonth() + 1).padStart(2, "0")}/${String(date.getDate()).padStart(2, "0")}/${date.getFullYear()} ${String(date.getHours()).padStart(2, "0")}:${String(date.getSeconds()).padStart(2, "0")}`;
-    return formattedDate;
-  };
   // Stryker disable all : hard to test for query caching
 
   // when delete success, invalidate the correct query key (depending on user role)

--- a/frontend/src/main/utils/RecommendationRequestUtils.js
+++ b/frontend/src/main/utils/RecommendationRequestUtils.js
@@ -14,3 +14,9 @@ export function cellToAxiosParamsDelete(cell) {
     },
   };
 }
+
+export const formattedDate = (val) => {
+  const date = new Date(val);
+  const formattedDate = `${String(date.getMonth() + 1).padStart(2, "0")}/${String(date.getDate()).padStart(2, "0")}/${date.getFullYear()} ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+  return formattedDate;
+};

--- a/frontend/src/tests/utils/RecommendationRequestUtils.test.js
+++ b/frontend/src/tests/utils/RecommendationRequestUtils.test.js
@@ -1,6 +1,7 @@
 import {
   onDeleteSuccess,
   cellToAxiosParamsDelete,
+  formattedDate,
 } from "main/utils/RecommendationRequestUtils";
 import mockConsole from "jest-mock-console";
 
@@ -45,6 +46,18 @@ describe("RecommendationRequestUtils", () => {
         method: "DELETE",
         params: { id: 17 },
       });
+    });
+  });
+  describe("formattedDate", () => {
+    test("It returns the correct date", () => {
+      // arrange
+      const val = "2023-10-01T12:34:56";
+
+      // act
+      const result = formattedDate(val);
+
+      // assert
+      expect(result).toEqual("10/01/2023 12:34");
     });
   });
 });

--- a/frontend/src/tests/utils/RecommendationRequestUtils.test.js
+++ b/frontend/src/tests/utils/RecommendationRequestUtils.test.js
@@ -51,17 +51,19 @@ describe("RecommendationRequestUtils", () => {
       });
     });
   });
-  
-  describe("formattedDate", () => {
-    test("It returns the correct date", () => {
-      // arrange
-      const val = "2023-10-01T12:34:56";
+});
 
-      // act
-      const result = formattedDate(val);
+describe("formattedDate", () => {
+  test("It returns the correct date", () => {
+    // arrange
+    const val = "2023-10-01T12:34:56";
 
-      // assert
-      expect(result).toEqual("10/01/2023 12:34");
+    // act
+    const result = formattedDate(val);
+
+    // assert
+    expect(result).toEqual("10/01/2023 12:34");
+  });
 
   describe("onUpdateStatusSuccess", () => {
     test("It puts the message on console.log and in a toast", () => {


### PR DESCRIPTION
Closes #45 

In this PR, I built on #41 and moved the date function into utils for reusability. I also added a test for the util function.

To check code, you can review the changes(not much). You can see I just moved the function and added a test.

Format Still Works:
<img width="1158" alt="Screenshot 2025-05-22 at 1 10 48 AM" src="https://github.com/user-attachments/assets/4e043b71-5e5e-498b-8853-541caf7280f3" />